### PR TITLE
Change Seeding Folder to root project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mechanism to automatically infer the mutations and data structure from the GraphQL API, to dynamically create some sample mutations based on a user's schema
 - Configuration option to link remote seeding to a specific Amplify environment
 
+## [0.1.10] - 2022-04-12
+- Moved the `seeding` folder from `amplify/backend/seeding/` to `graphql-seed/`. This is to prevent the folder being deleted after running `amplify pull`. For more information, see the [bug report](https://github.com/awslabs/amplify-graphql-seed-plugin/issues/22) by robotsrng@
+- Added README.md file to be added to this new folder to give a brief explanation about the contents of the folder, e.g. for new developers.
+
 ## [0.1.9] - 2022-04-11
 - Added information to the README regarding installation issues with the new Amplify CLI version (8.0.0). See this [bug report](https://github.com/aws-amplify/amplify-cli/issues/10180) for more info.
 
@@ -45,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - local and remote seeding for the following Authentication types: AWS_IAM, API_KEY and Cognito User pools
   - ability to link into amplify hooks to enable commands like `amplify mock --seed`
 
+[0.1.10]: https://github.com/awslabs/amplify-graphql-seed-plugin/releases/tag/v0.1.10
 [0.1.9]: https://github.com/awslabs/amplify-graphql-seed-plugin/releases/tag/v0.1.9
 [0.1.8]: https://github.com/awslabs/amplify-graphql-seed-plugin/releases/tag/v0.1.8
 [0.1.7]: https://github.com/awslabs/amplify-graphql-seed-plugin/releases/tag/v0.1.7

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ We assume that by this stage you already have a GraphQL API configured in your p
 amplify graphql-seed init
 ```
 ### Step 2. Adjust the generated `seed-data.js` file to your needs
-The init file has created the `amplify/backend/seeding/seed-data.js` file. Adjust mutations and data to run your custom seeding. See [this section](#customizing-your-seed-file) of the readme for more details.
+The init file has created the `graphql-seed/seed-data.js` file. Adjust mutations and data to run your custom seeding. See [this section](#customizing-your-seed-file) of the readme for more details.
 
 ### Step 3. Run the plugin to seed your database
 **Option 1:** Start your mock database, and seed it:
@@ -102,27 +102,32 @@ Below, you can find the available commands to interact with our plugin:
 | ```amplify graphql-seed remove ``` | | Allows you to remove the files created by this plugin. |
 
 ## How does it work? 🤔
-Using the `init` command, the plugin will create a set of files for you which it uses for seeding your database which you can customize. In particular, it creates two new directories in your amplify folder called **backend/seeding** and **hooks** with the following files:
+Using the `init` command, the plugin will create a set of files for you which it uses for seeding your database which you can customize. In particular, it creates two new directories in your amplify folder called **graphql-seed** and **hooks** with the following files:
 ```
 .
 ├── ...
 ├── amplify
 │   ├── backend
 │   │   ├── integration
-    │   ├── api
-    │   ├── auth
-    │   ├── ...
-    │   ├── seeding
-    │       ├── configurations.json # new
-    │       ├── credentials.json    # new
-    │       ├── customMutations.js  # new
-    │       ├── seed-data.js        # new
-    │       ├── .gitignore          # new
-    │
-    ├── hooks
-        ├── post-mock.sh # new
-        ├── post-push.sh # new
-        ├── pre-mock.sh  # new
+│   │   ├── api
+│   │   ├── auth
+│   │   ├── ...
+│   │
+│   ├── hooks
+│       ├── post-mock.sh # new
+│       ├── post-push.sh # new
+│       ├── pre-mock.sh  # new
+│
+├── graphql-seed
+│   ├── configurations.json # new
+│   ├── credentials.json    # new
+│   ├── customMutations.js  # new
+│   ├── seed-data.js        # new
+│   ├── .gitignore          # new
+│   ├── README.md           # new
+│
+├── src
+    ├── ...
 ```
 The files have the following contents:
 - `configurations.json` - holds the configuration of the plugin based on information the plugin found. You can override any values in this file.
@@ -152,7 +157,7 @@ type Todo @model @auth(rules: [
 ```
 **Note: the above example allows all different authentication types supported by this plugin. Your case might differ. Take a look at this [section](#authentication-options) **
 
-When you created the file with the `init` command, it automatically added some sample code to `amplify/backend/seeding/seed-data.js`. If you have auto-generated mutations in your project (from Amplify codegen), they will be imported at the top of the file. To create seed data, you'll add entries to the seed-data.js file in the following format (an example is automatically added):
+When you created the file with the `init` command, it automatically added some sample code to `graphql-seed/seed-data.js`. If you have auto-generated mutations in your project (from Amplify codegen), they will be imported at the top of the file. To create seed data, you'll add entries to the seed-data.js file in the following format (an example is automatically added):
 ```javascript
 import * as mutations from "../../../src/graphql/mutations.js"
 import * as customMutations from "./customMutations.js"
@@ -214,7 +219,7 @@ backend:
 ```
 This will install the plugin using npm, add the plugin to the Amplify environment (note that "printf 'Y'" is required to confirm adding it without user-input), and it will install jq as a pre-requisite package.
 
-During the build, the environment will be pushed, and the seeding script will be run based on the code checked in under `amplify/backend/seeding` in the underlying Version Control System.
+During the build, the environment will be pushed, and the seeding script will be run based on the code checked in under `graphql-seed/` in the underlying Version Control System.
 
 **!! Important !!**
 If you are using the Amplify CI/CD pipelines, or if you're encountering a ``SyntaxError: Cannot use import statement outside a module`` error in your build, please ensure that you're using a Node version larger than 14 in your pipeline (we recommend using Node v16 or higher). In Amplify, you can do this in the console by navigating to your app > App Settings > Build Settings. At the bottom of the page, in Build image settings, click on the Edit button and specify the Node.js version which the pipeline should use by adding a package version override. As of 30th of March 2022, Amplify is actually using Node version v14.19.0 (even if you set it to 'latest'), so you need to explicitly set the version to a higher version.
@@ -224,7 +229,7 @@ If you are using the Amplify CI/CD pipelines, or if you're encountering a ``Synt
 ### Specify remote environments for seeding
 When using this plugin to seed remote environments, either through CI/CD pipelines or by using the `amplify graphql-seed run --remote` command, you can specify which environments should be used for seeding. By doing so, you can prevent accidentally seeding the wrong environment.
 
-For example, if you have your CI/CD pipelines in Amplify, you have access to the `$USER_BRANCH` environment variable which defines what environment the CI/CD pipeline is run for. Suppose you want to allow the pipeline to seed the `dev` and `staging` environments, but not the `prod` environment. You can achieve this by adjusting the `amplify/backend/seeding/configuration.json` file to this:
+For example, if you have your CI/CD pipelines in Amplify, you have access to the `$USER_BRANCH` environment variable which defines what environment the CI/CD pipeline is run for. Suppose you want to allow the pipeline to seed the `dev` and `staging` environments, but not the `prod` environment. You can achieve this by adjusting the `graphql-seed/configuration.json` file to this:
 ```json
 {
 	"mutationsFile": "customMutations.js",

--- a/commands/init.js
+++ b/commands/init.js
@@ -16,7 +16,7 @@ async function run (context) {
   // Step 1: Find existing mutations file in src/
   const mutationsFile = await findMutationsFile(context)
 
-  // Step 2: Create amplify/backend/seeding directory if it doesn't exist
+  // Step 2: Create graphql-seed/ directory if it doesn't exist
   const seedDir = utils.getSeedingDirectory(context)
   if (!fs.existsSync(seedDir)) {
     fs.mkdirSync(seedDir)
@@ -25,7 +25,7 @@ async function run (context) {
   // Step 3: Create Sample Mutations for custom mutations
   await createMutationFile(context, mutationsFile)
 
-  // Step 4: Create seeding file in amplify/backend/seeding with some example mutations
+  // Step 4: Create seeding file in graphql-seed/ with some example mutations
   await createSeedingFile(context, mutationsFile)
 
   // Step 5: Create Hook files
@@ -37,7 +37,10 @@ async function run (context) {
   // Step 7: Create configuration file
   await createConfigurationFile(context)
 
-  // Step 8: Print results of all files added
+  // Step 8: Add the README.md file
+  await addInitFile(context, constants.SAMPLE_README_FILENAME, constants.README_FILENAME)
+
+  // Step 9: Print results of all files added
   if (createdFiles.length > 0) {
     context.print.success('\n\n✅  Seeding files have been created successfully (see below), you can edit them and run the \'amplify graphql-seed run\' command to seed your database. \n')
     for (const file of createdFiles) {
@@ -169,7 +172,7 @@ async function createHookFiles (context) {
 }
 
 /**
- * This function will take a file from the sample-files from the graphql-seed plugin and copy them to the amplify/backend/seeding directory
+ * This function will take a file from the sample-files from the graphql-seed plugin and copy them to the graphql-seed/ directory
  * @param {*} context - context of the plugin
  * @param {*} srcFileName - file name of the sample file
  * @param {*} destFileName - file name of the destination file

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amplify-graphql-seed-plugin",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "AWS Amplify plugin for local and remote seeding of GraphQL API.",
   "author": "Michal Juras and Laurens Brinker, Amazon Web Services",
   "engines": {

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -1,5 +1,5 @@
 const SEED_FILE_NAME = 'seed-data.js'
-const SEED_BACKEND_FOLDER = 'seeding'
+const SEED_BACKEND_FOLDER = 'graphql-seed'
 
 const SAMPLE_MUTATIONS_FILE_NAME = 'example-mutation-file.js'
 
@@ -17,6 +17,9 @@ const PRE_MOCK_FILENAME = 'pre-mock.sh'
 
 const SAMPLE_POST_PUSH_FILENAME = 'example-post-push-file.sh'
 const POST_PUSH_FILENAME = 'post-push.sh'
+
+const SAMPLE_README_FILENAME = 'example-readme.md'
+const README_FILENAME = 'README.md'
 
 const REMOTE_SEED_ARGUMENT = 'remote'
 const LOCAL_SEED_ARGUMENT = 'local'
@@ -123,5 +126,7 @@ module.exports = {
   EXAMPLE_GITIGNORE_FILENAME,
   GITIGNORE_FILENAME,
   RUNHELP,
-  RUNARGUMENTSCHEMA
+  RUNARGUMENTSCHEMA,
+  SAMPLE_README_FILENAME,
+  README_FILENAME
 }

--- a/utils/directory-functions.js
+++ b/utils/directory-functions.js
@@ -51,7 +51,7 @@ module.exports.getHooksFileLocation = (context, fileName) => {
 
 module.exports.getSeedingDirectory = (context) => {
   const backendDir = module.exports.getBackendDirectory(context)
-  return path.normalize(path.join(backendDir, SEED_BACKEND_FOLDER))
+  return path.normalize(path.join(backendDir, `../../${SEED_BACKEND_FOLDER}`))
 }
 
 module.exports.getSampleDirectory = () => {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/amplify-graphql-seed-plugin/issues/22

*Description of changes:*
- Moved the `seeding` folder from `amplify/backend/seeding/` to `graphql-seed/`. This is to prevent the folder being deleted after running `amplify pull`. For more information, see the [bug report](https://github.com/awslabs/amplify-graphql-seed-plugin/issues/22) by robotsrng@
- Added README.md file to be added to this new folder to give a brief explanation about the contents of the folder, e.g. for new developers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
