### PR TITLE
Enabled COGNITO_AUTHENTICATION as a secondary auth types

### DIFF
--- a/commands/run.js
+++ b/commands/run.js
@@ -191,9 +191,11 @@ const executeMutationsFromOperation = async (executionProps) => {
 const runGraphqlMutation = async (mutation, input, authenticationToUse, mutationProps, context) => {
   let response = {}
   if (authenticationToUse === COGNITO_AUTHENTICATION) {
-    response = await API.graphql(graphqlOperation(
-      mutation, { input }
-    ))
+    response = await API.graphql({
+        query: gql`${mutation}`,
+        variables: { input },
+        authMode: COGNITO_AUTHENTICATION
+    })
   } else {
     const { clients } = mutationProps
     const client = clients[authenticationToUse]


### PR DESCRIPTION
Use authMode to enable COGNITO_AUTHENTICATION as a secondary auth types

*Issue #, if available:*

*Description of changes:*
use `authMode` attribution to handle the issue when cognito authentication is the secondary auth method


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
